### PR TITLE
- Substitute cpu usage with old value if $dt is equal to 0 to prevent division by zero

### DIFF
--- a/proc-cpuusage/lib/Proc/CPUUsage.pm
+++ b/proc-cpuusage/lib/Proc/CPUUsage.pm
@@ -8,15 +8,15 @@ use Time::HiRes qw( gettimeofday tv_interval );
 sub new {
   my $class = shift;
   
-  return bless [ [gettimeofday()], _cpu_time() ], $class;
+  return bless [ [gettimeofday()], _cpu_time(), 0 ], $class;
 }
 
 sub usage {
   my $self = $_[0];
-  my ($t0, $r0) = @$self;
+  my ($t0, $r0, $l0) = @$self;
   return unless defined $r0;
   
-  my ($dt, $dr, $t1, $r1);
+  my ($dt, $dr, $t1, $r1, $l1);
   $t1 = [gettimeofday()];
   $dt = tv_interval($t0, $t1);
   $self->[0] = $t1;
@@ -24,8 +24,11 @@ sub usage {
   $r1 = _cpu_time();
   $dr = $r1 - $r0;
   $self->[1] = $r1;
-  
-  return $dr/$dt;
+
+  $l1 = $dt == 0 ? $l0 : $dr/$dt;
+  $self->[2] = $l1;
+
+  return $l1;
 }
 
 sub _cpu_time {

--- a/proc-cpuusage/lib/Proc/CPUUsage.pm
+++ b/proc-cpuusage/lib/Proc/CPUUsage.pm
@@ -13,10 +13,10 @@ sub new {
 
 sub usage {
   my $self = $_[0];
-  my ($t0, $r0, $l0) = @$self;
+  my ($t0, $r0, $u0) = @$self;
   return unless defined $r0;
   
-  my ($dt, $dr, $t1, $r1, $l1);
+  my ($dt, $dr, $t1, $r1, $u1);
   $t1 = [gettimeofday()];
   $dt = tv_interval($t0, $t1);
   $self->[0] = $t1;
@@ -25,10 +25,10 @@ sub usage {
   $dr = $r1 - $r0;
   $self->[1] = $r1;
 
-  $l1 = $dt == 0 ? $l0 : $dr/$dt;
-  $self->[2] = $l1;
+  $u1 = $dt == 0 ? $u0 : $dr/$dt;
+  $self->[2] = $u1;
 
-  return $l1;
+  return $u1;
 }
 
 sub _cpu_time {


### PR DESCRIPTION
I rarely receive the error message below I checked the code and I think maybe we can prevent this error message by checking the $dt variable.
 
[error] Illegal division by zero at "cpan/local/lib/perl5/Proc/CPUUsage.pm" line 31.