### PR TITLE
Fix broken unittests with returning undef on `_cpu_time`

### DIFF
--- a/proc-cpuusage/lib/Proc/CPUUsage.pm
+++ b/proc-cpuusage/lib/Proc/CPUUsage.pm
@@ -33,7 +33,7 @@ sub usage {
 
 sub _cpu_time {
   my ($utime, $stime) = getrusage();
-  return unless defined $utime && defined $stime;
+  return undef unless defined $utime && defined $stime;
   return $utime+$stime;
 }
 


### PR DESCRIPTION
After [this](https://github.com/melo/proc-metrics/pull/4) pull request unit-tests [fails](https://rt.cpan.org/Public/Bug/Display.html?id=133147) because of returning `0` instead of `undef`. fixed by returning undef instead of nothing in `_cpu_time`